### PR TITLE
[ShowIpad] ShowIpad 뷰 내부에서 쓰일 공통 헤더 구현

### DIFF
--- a/src/components/ShowIpad/Header/ShowIpadHeader.style.ts
+++ b/src/components/ShowIpad/Header/ShowIpadHeader.style.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+export const HeaderContainer = styled.header`
+  display: flex;
+  ${({ theme: { fonts } }) => fonts.subheading1_1};
+
+  margin-bottom: 2rem;
+`;
+
+export const Title = styled.p`
+  color: ${({ theme: { colors } }) => colors.grayScale.gray8};
+`;
+
+export const SubTitle = styled.p`
+  color: ${({ theme: { colors } }) => colors.grayScale.gray6};
+`;

--- a/src/components/ShowIpad/Header/ShowIpadHeader.style.ts
+++ b/src/components/ShowIpad/Header/ShowIpadHeader.style.ts
@@ -5,6 +5,8 @@ export const HeaderContainer = styled.header`
   ${({ theme: { fonts } }) => fonts.subheading1_1};
 
   margin-bottom: 2rem;
+
+  gap: 0.2rem;
 `;
 
 export const Title = styled.p`

--- a/src/components/ShowIpad/Header/index.tsx
+++ b/src/components/ShowIpad/Header/index.tsx
@@ -1,0 +1,17 @@
+import * as S from './ShowIpadHeader.style';
+
+interface ShowIpadHeaderProps {
+  title: string;
+  subTitle: string;
+}
+
+const ShowIpadHeader = ({ title, subTitle }: ShowIpadHeaderProps) => {
+  return (
+    <S.HeaderContainer>
+      <S.Title>{title}</S.Title>
+      <S.SubTitle>{subTitle}</S.SubTitle>
+    </S.HeaderContainer>
+  );
+};
+
+export default ShowIpadHeader;

--- a/src/pages/ShowIpad/ShowIpadPage.tsx
+++ b/src/pages/ShowIpad/ShowIpadPage.tsx
@@ -1,0 +1,5 @@
+const ShowIpadPage = () => {
+  return <div>ShowIpadPage</div>;
+};
+
+export default ShowIpadPage;


### PR DESCRIPTION
## 🔥 Related Issues
resolved #17 

## 💜 작업 내용
- [x] 헤더 컴포넌트 구현
- [x] 각 내용은 props로 받아옴.

## ✅ PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
  - 크게 어려운 내용은 없고, 각 섹션 별 헤더에 들어갈 내용을 각각 title과 subTitle로 받아왔습니다.
  ``` typescript
  const ShowIpadHeader = ({ title, subTitle }: ShowIpadHeaderProps) => {
  return (
    <S.HeaderContainer>
      <S.Title>{title}</S.Title>
      <S.SubTitle>{subTitle}</S.SubTitle>
    </S.HeaderContainer>
    );
  };
  ```

  - 사용할 땐 아래와 같이 사용하면 됩니다 !
  ``` typescript
   <ShowIpadHeader title='모든 모델.' subTitle='당신의 선택은?' />
   <ShowIpadHeader title='쇼핑 안내.' subTitle='결정을 못하겠다면 여기에서' />
   ...
  ```

## 😡 Trouble Shooting
- 없음.

## ☀️ 스크린샷 / GIF / 화면 녹화 
<img width="1291" alt="스크린샷 2023-11-23 오후 8 21 32" src="https://github.com/DO-SOPT-CDS-SEMINAR/Apple-Client/assets/80264647/5c5812de-9177-4f7c-b531-59870b7baca9">
