### PR TITLE
[Main]상단 구매항목 Category List 구현 

### DIFF
--- a/src/components/Category/Category.style.ts
+++ b/src/components/Category/Category.style.ts
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+
+export const CategoryWrapper = styled.section`
+  justify-content: center;
+  display: flex;
+
+  width: 100vw;
+  height: 23.6rem;
+  padding-top: 1rem;
+
+  background-color: ${({ theme: { colors } }) => colors.grayScale.gray2};
+`;
+
+export const ListItemContainer = styled.div`
+  width: 13.6rem;
+  height: 14.8rem;
+  margin: 0 0.25rem;
+
+  cursor: pointer;
+`;
+
+export const ListName = styled.p`
+  width: 12rem;
+  text-align: center;
+  margin: 0rem 0.8rem;
+
+  color: ${({ theme: { colors } }) => colors.grayScale.gray8};
+
+  font: ${({ theme: { fonts } }) => fonts.body3};
+`;
+
+export const imgUrl = styled.img`
+  width: 12rem;
+  height: 7.8rem;
+  margin: 1.6rem 0.8rem;
+`;

--- a/src/components/Category/ListItem.tsx
+++ b/src/components/Category/ListItem.tsx
@@ -1,0 +1,18 @@
+import * as S from './Category.style';
+
+interface ListItemProps {
+  idx: number;
+  ListName: string;
+  imgUrl: string;
+}
+
+const ListItem = ({ ListName, imgUrl }: ListItemProps) => {
+  return (
+    <S.ListItemContainer>
+      <S.ListName>{ListName}</S.ListName>
+      <S.imgUrl src={imgUrl} alt='itemImage'></S.imgUrl>
+    </S.ListItemContainer>
+  );
+};
+
+export default ListItem;

--- a/src/components/Category/index.tsx
+++ b/src/components/Category/index.tsx
@@ -1,0 +1,67 @@
+import * as S from './Category.style';
+import ListItem from './ListItem';
+
+const DUMMY = [
+  {
+    id: 1,
+    listName: 'Mac',
+    imgUrl:
+      'https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/store-card-13-ipad-nav-202210?wid=400&hei=260&fmt=png-alpha&.v=1664912135437',
+  },
+  {
+    id: 2,
+    listName: 'iPhone',
+    imgUrl:
+      'https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/store-card-13-ipad-nav-202210?wid=400&hei=260&fmt=png-alpha&.v=1664912135437',
+  },
+  {
+    id: 3,
+    listName: 'iPad',
+    imgUrl:
+      'https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/store-card-13-ipad-nav-202210?wid=400&hei=260&fmt=png-alpha&.v=1664912135437',
+  },
+  {
+    id: 4,
+    listName: 'Apple Watch',
+    imgUrl:
+      'https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/store-card-13-ipad-nav-202210?wid=400&hei=260&fmt=png-alpha&.v=1664912135437',
+  },
+  {
+    id: 5,
+    listName: 'AirPods',
+    imgUrl:
+      'https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/store-card-13-ipad-nav-202210?wid=400&hei=260&fmt=png-alpha&.v=1664912135437',
+  },
+  {
+    id: 6,
+    listName: 'AirTag',
+    imgUrl:
+      'https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/store-card-13-ipad-nav-202210?wid=400&hei=260&fmt=png-alpha&.v=1664912135437',
+  },
+  {
+    id: 7,
+    listName: 'Apple TV 4K',
+    imgUrl:
+      'https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/store-card-13-ipad-nav-202210?wid=400&hei=260&fmt=png-alpha&.v=1664912135437',
+  },
+  {
+    id: 8,
+    listName: '악세사리',
+    imgUrl:
+      'https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/store-card-13-ipad-nav-202210?wid=400&hei=260&fmt=png-alpha&.v=1664912135437',
+  },
+];
+
+const Category = () => {
+  return (
+    <S.CategoryWrapper>
+      {DUMMY.map((item) => {
+        return (
+          <ListItem key={item.id} idx={item.id} ListName={item.listName} imgUrl={item.imgUrl} />
+        );
+      })}
+    </S.CategoryWrapper>
+  );
+};
+
+export default Category;


### PR DESCRIPTION
## 🔥 Related Issues
resolved #31 

## 💜 작업 내용
- [x] ~ Category 영역 만들기
- [x] ~ 내부 컴포넌트(이동 버튼)

## ✅ PR Point
- API 연결을 통해 가져올 이미지와 텍스트라 우선 DUMMY DATA로 넣어두었습니다! 
- Map 통해서 데이터 불러와서 category item 생성되게 하였습니다.

```typescript
import * as S from './Category.style';
import ListItem from './ListItem';

const DUMMY = [
  {
    id: 1,
    listName: 'Mac',
    imgUrl:
      'https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/store-card-13-ipad-nav-202210?wid=400&hei=260&fmt=png-alpha&.v=1664912135437',
  },
  {
    id: 2,
    listName: 'iPhone',
    imgUrl:
      'https://store.storeimages.cdn-apple.com/4982/as-images.apple.com/is/store-card-13-ipad-nav-202210?wid=400&hei=260&fmt=png-alpha&.v=1664912135437',
  },
//더미 데이터 생략

// 전체 카테고리 박스
const Category = () => {
  return (
    <S.CategoryWrapper>
      {DUMMY.map((item) => {
        return (
          <ListItem key={item.id} idx={item.id} ListName={item.listName} imgUrl={item.imgUrl} />
        );
      })}
    </S.CategoryWrapper>
  );
};

export default Category;

``` 

```typescript
//카테고리 컴포넌트

interface ListItemProps {
  idx: number;
  ListName: string;
  imgUrl: string;
}

const ListItem = ({ ListName, imgUrl }: ListItemProps) => {
  return (
    <S.ListItemContainer>
      <S.ListName>{ListName}</S.ListName>
      <S.imgUrl src={imgUrl} alt='itemImage'></S.imgUrl>
    </S.ListItemContainer>
  );
};

export default ListItem;


``` 


## 😡 Trouble Shooting
- Main에서 develop pull 안받고 시작하는 바람에 conflict가 났었어요... 너무 대공사일 것 같아서 아예 Main 브랜치 지우고, 다시 Main/#~~~ 세부 브랜치 파서 해결했습니다..ㅎㅎ휴..

## ☀️ 스크린샷 / GIF / 화면 녹화 
<img width="1444" alt="스크린샷 2023-11-27 오전 12 19 08" src="https://github.com/DO-SOPT-CDS-SEMINAR/Apple-Client/assets/111034927/887988e7-3407-4c90-b4e8-73651625fd30">
