### PR TITLE
[AddAccessory]모달 위 메뉴 토글버튼 퍼블리싱/ 클릭 시 색변화 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import GlobalStyle from './styles/GlobalStyle';
 import { ThemeProvider } from 'styled-components';
 import theme from './styles/theme';
 import './styles/fonts/fonts.css';
+import ToggleMenu from './components/AddAccessory/toggle';
 
 function App() {
   console.log('초기세팅 완료');
@@ -11,6 +12,7 @@ function App() {
     <RecoilRoot>
       <ThemeProvider theme={theme}>
         <GlobalStyle />
+        <ToggleMenu />
       </ThemeProvider>
     </RecoilRoot>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import GlobalStyle from './styles/GlobalStyle';
 import { ThemeProvider } from 'styled-components';
 import theme from './styles/theme';
 import './styles/fonts/fonts.css';
-import ToggleMenu from './components/AddAccessory/toggle';
 
 function App() {
   console.log('초기세팅 완료');
@@ -12,7 +11,6 @@ function App() {
     <RecoilRoot>
       <ThemeProvider theme={theme}>
         <GlobalStyle />
-        <ToggleMenu />
       </ThemeProvider>
     </RecoilRoot>
   );

--- a/src/components/AddAccessory/toggle/ToggleButton.tsx
+++ b/src/components/AddAccessory/toggle/ToggleButton.tsx
@@ -1,8 +1,9 @@
+import { ReactNode } from 'react';
 import * as S from './ToggleMenu.style';
 
 interface ToggleButtonProps {
   idx: number;
-  ButtonName: string;
+  ButtonName: ReactNode;
   onClick: (id: number) => void;
   isActive: boolean;
 }

--- a/src/components/AddAccessory/toggle/ToggleButton.tsx
+++ b/src/components/AddAccessory/toggle/ToggleButton.tsx
@@ -1,0 +1,18 @@
+import * as S from './ToggleMenu.style';
+
+interface ToggleButtonProps {
+  idx: number;
+  ButtonName: string;
+  onClick: (id: number) => void;
+  isActive: boolean;
+}
+
+const ToggleButton = ({ idx, ButtonName, onClick, isActive }: ToggleButtonProps) => {
+  return (
+    <S.Button onClick={() => onClick(idx)} $isActive={isActive}>
+      {ButtonName}
+    </S.Button>
+  );
+};
+
+export default ToggleButton;

--- a/src/components/AddAccessory/toggle/ToggleMenu.style.ts
+++ b/src/components/AddAccessory/toggle/ToggleMenu.style.ts
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+interface ButtonProps {
+  $isActive: boolean;
+}
+
+export const ToggleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  vertical-algin: center;
+
+  width: 59.4rem;
+  height: 5rem;
+  border-radius: 2.5rem;
+
+  background-color: ${({ theme }) => theme.colors.grayScale.gray2};
+`;
+
+// eslint-disable-next-line prettier/prettier
+export const Button = styled.button<ButtonProps>`
+  width: 11.8rem;
+  height: 4.6rem;
+
+  border-radius: 2.3rem;
+
+  color: ${({ theme: { colors }, $isActive }) =>
+    $isActive ? colors.grayScale.white : colors.grayScale.gray6};
+  background-color: ${({ theme: { colors }, $isActive }) =>
+    $isActive ? colors.grayScale.gray8 : colors.grayScale.gray2};
+
+  font: ${({ theme: { fonts } }) => fonts.body1};
+
+  cursor: pointer;
+`;

--- a/src/components/AddAccessory/toggle/index.tsx
+++ b/src/components/AddAccessory/toggle/index.tsx
@@ -1,0 +1,32 @@
+import * as S from './ToggleMenu.style';
+import { useState } from 'react';
+
+import ToggleButton from './ToggleButton';
+import { TOGGLE_MEMU } from '../../../constant/toggleMenu';
+
+const ToggleMenu = () => {
+  const [isActive, setIsActive] = useState<number | null>(TOGGLE_MEMU[0]?.idx || null);
+
+  const activateBtn = (idx: number) => {
+    setIsActive(idx);
+  };
+
+  return (
+    <S.ToggleWrapper>
+      {TOGGLE_MEMU.map((item) => {
+        return (
+          <ToggleButton
+            key={item.idx}
+            idx={item.idx}
+            ButtonName={item.buttonName}
+            onClick={activateBtn}
+            isActive={isActive === item.idx}
+          />
+        );
+      })}
+      ;
+    </S.ToggleWrapper>
+  );
+};
+
+export default ToggleMenu;

--- a/src/constant/toggleMenu.ts
+++ b/src/constant/toggleMenu.ts
@@ -1,0 +1,22 @@
+export const TOGGLE_MEMU = [
+  {
+    idx: 1,
+    buttonName: '펜슬',
+  },
+  {
+    idx: 2,
+    buttonName: '케이스',
+  },
+  {
+    idx: 3,
+    buttonName: '케이블',
+  },
+  {
+    idx: 4,
+    buttonName: '어댑터',
+  },
+  {
+    idx: 5,
+    buttonName: '기타',
+  },
+];


### PR DESCRIPTION
## 🔥 Related Issues
resolved #40 

## 💜 작업 내용
- [x] ~ 토클 버튼 퍼블리싱
- [x] ~ 클릭시 색상변화 
- [x] ~ default값으로 첫번째 버튼 선택

## ✅ PR Point

- constant에 토글메뉴 데이터 따로 빼서 제작
```typescript


export const TOGGLE_MEMU = [
  {
    idx: 1,
    buttonName: '펜슬',
  },
  {
    idx: 2,
    buttonName: '케이스',
  },
  {
    idx: 3,
    buttonName: '케이블',
  },
  {
    idx: 4,
    buttonName: '어댑터',
  },
  {
    idx: 5,
    buttonName: '기타',
  },
];

``` 
- id값을 보내서 해당되는 버튼에만 핸들러 작동하도록

```typescript
 <S.ToggleWrapper>
      {TOGGLE_MEMU.map((item) => {
        return (
          <ToggleButton
            key={item.idx}
            idx={item.idx}
            ButtonName={item.buttonName}
            onClick={activateBtn}
            isActive={isActive === item.idx}
          />
        );
      })}
      ;
    </S.ToggleWrapper>
``` 
- 유니온으로 초기 버튼값 설정
```typescript

const ToggleMenu = () => {
  const [isActive, setIsActive] = useState<number | null>(TOGGLE_MEMU[0]?.idx || null);

``` 


## 😡 Trouble Shooting
- NB랑 구현하는 방식이 거의 비슷해서 지난번 `$isActive ` 트러블 슈팅했던것 복습하면서 구현했습니다!

## ☀️ 스크린샷 / GIF / 화면 녹화 

https://github.com/DO-SOPT-CDS-SEMINAR/Apple-Client/assets/111034927/faf1e11e-c778-4fb5-8b4d-17919962f401

