### PR TITLE
[Main] Main 뷰 내부에서 쓰일 공통 헤더 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import GlobalStyle from './styles/GlobalStyle';
 import { ThemeProvider } from 'styled-components';
 import theme from './styles/theme';
 import './styles/fonts/fonts.css';
-import MainPage from './pages/Main';
 
 function App() {
   console.log('초기세팅 완료');
@@ -12,7 +11,6 @@ function App() {
     <RecoilRoot>
       <ThemeProvider theme={theme}>
         <GlobalStyle />
-        <MainPage />
       </ThemeProvider>
     </RecoilRoot>
   );

--- a/src/components/Main/SectionHeader/SectionHeader.style.ts
+++ b/src/components/Main/SectionHeader/SectionHeader.style.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+export const HeaderContainer = styled.header`
+  display: flex;
+
+  margin-bottom: 1rem;
+
+  ${({ theme: { fonts } }) => fonts.subheading1_1};
+
+  gap: 0.2rem;
+`;
+
+export const Title = styled.p`
+  color: ${({ theme: { colors } }) => colors.pointColor.red0};
+`;
+
+export const SubTitle = styled.p`
+  color: ${({ theme: { colors } }) => colors.grayScale.gray6};
+`;

--- a/src/components/Main/SectionHeader/index.tsx
+++ b/src/components/Main/SectionHeader/index.tsx
@@ -1,0 +1,17 @@
+import * as S from './SectionHeader.style';
+
+interface SectionHeaderProps {
+  title: string;
+  subtitle: string;
+}
+
+const SectionHeader = ({ title, subtitle }: SectionHeaderProps) => {
+  return (
+    <S.HeaderContainer>
+      <S.Title>{title}</S.Title>
+      <S.SubTitle>{subtitle}</S.SubTitle>
+    </S.HeaderContainer>
+  );
+};
+
+export default SectionHeader;


### PR DESCRIPTION
## 🔥 Related Issues
resolved #38 

## 💜 작업 내용
- [x] ~ 헤더 컴포넌트 구현
- [x] ~ 각 내용은 props로 받아옴.

## ✅ PR Point

```typescript

interface SectionHeaderProps {
  title: string;
  subtitle: string;
}

const SectionHeader = ({ title, subtitle }: SectionHeaderProps) => {
  return (
    <S.HeaderContainer>
      <S.Title>{title}</S.Title>
      <S.SubTitle>{subtitle}</S.SubTitle>
    </S.HeaderContainer>
  );
};


``` 

## 😡 Trouble Shooting
- 없습니다!

## ☀️ 스크린샷 / GIF / 화면 녹화 
<img width="858" alt="스크린샷 2023-11-28 오후 8 54 29" src="https://github.com/DO-SOPT-CDS-SEMINAR/Apple-Client/assets/111034927/38443964-26c9-4435-bc33-4c2b2df330d1">
