### PR TITLE
[Init] 페이지마다 배경색 다르게 들어가도록 구현

### DIFF
--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -1,3 +1,4 @@
+import { PageController } from './../common/PageController/index';
 import { createGlobalStyle, css } from 'styled-components';
 
 export const reset = css`
@@ -145,6 +146,16 @@ ${reset}
 
 * {
     box-sizing: border-box;
+}
+
+body {
+  .white {
+    background-color: ${({ theme: { colors } }) => colors.grayScale.white};
+  }
+
+  .gray{
+    background-color: ${({ theme: { colors } }) => colors.grayScale.gray2};
+  }
 }
 
 // 사파리 웹 뷰 브라우저 상속 스타일 제거


### PR DESCRIPTION
## 🔥 Related Issues
resolved #46 

## 💜 작업 내용
- [x] 페이지마다 배경색이 다르게 들어가도록 구현했습니다.

## ✅ PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
  - 뷰마다 배경색이 다르게 들어가게 하는 방법이 뭐가 있을까 고민하다가 가장 간단한 방법인 `className`을 선택했습니다.
  현재는 뷰의 개수가 많지 않기 때문에 이 방식으로 구현이 가능하다고 판단했습니다.
  간단하게 GlobalStyle.ts 코드를 수정해주었고, 아래 코드 참고하시면 됩니다.
  ```typescript
  body {
  .white {
    background-color: ${({ theme: { colors } }) => colors.grayScale.white};
    }

    .gray{
      background-color: ${({ theme: { colors } }) => colors.grayScale.gray2};
    }
  }
  ```
  
  - 단, 해당 코드를 사용하기 위해서는 각 페이지 뷰에서 className을 white 또는 gray로 지정해주셔야 합니다.
  ```typescript
   const ShowIpadPage = () => {
     return (
       <div className='gray'>
         <ShowAllProducts />;
       <div>
   };
 ```

## 😡 Trouble Shooting
- 어떤 어려움이 있었고 어떻게 해결했는지
  - 위에 작성한 내용이 전부인 태스크입니다.

## ☀️ 스크린샷 / GIF / 화면 녹화 
  - 따로 없음.