### PR TITLE
[Common] 공통으로 사용할 footer 구현

### DIFF
--- a/src/common/Footer/CommonFooter/CommonFooter.style.ts
+++ b/src/common/Footer/CommonFooter/CommonFooter.style.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+export const CommonFooterContainer = styled.div`
+  width: 98rem;
+  height: 50.9rem;
+  margin: 0 auto;
+  padding: 1.7rem 0 1.1rem;
+`;
+
+export const ContentsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  gap: 1rem;
+`;
+
+export const Contents = styled.div`
+  color: ${({ theme: { colors } }) => colors.grayScale.gray6};
+  ${({ theme: { fonts } }) => fonts.caption2};
+`;

--- a/src/common/Footer/CommonFooter/CommonFooter.style.ts
+++ b/src/common/Footer/CommonFooter/CommonFooter.style.ts
@@ -1,8 +1,12 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+
+interface ContentsProps {
+  $addMarginTop?: number;
+}
 
 export const CommonFooterContainer = styled.div`
   width: 98rem;
-  height: 50.9rem;
+  /* height: 50.9rem; */
   margin: 0 auto;
   padding: 1.7rem 0 1.1rem;
 `;
@@ -14,7 +18,9 @@ export const ContentsContainer = styled.div`
   gap: 1rem;
 `;
 
-export const Contents = styled.div`
+export const Contents = styled.div<ContentsProps>`
+  margin-top: ${({ $addMarginTop }) => ($addMarginTop === 5 || $addMarginTop === 10) && css`1rem`};
+
   color: ${({ theme: { colors } }) => colors.grayScale.gray6};
   ${({ theme: { fonts } }) => fonts.caption2};
 `;

--- a/src/common/Footer/CommonFooter/index.tsx
+++ b/src/common/Footer/CommonFooter/index.tsx
@@ -4,23 +4,47 @@ import * as S from './CommonFooter.style';
 const CommonFooter = () => {
   const { res } = useGetFooterContetnts();
   const topContents = res?.slice(0, 4);
-  const bottomContents = res?.slice(4, res.length);
+  const middleContents = res?.slice(3, 7);
+  const middle2Contents = res?.slice(7, 9);
+  const bottomContents = res?.slice(9, res.length - 1);
 
   return (
     <S.CommonFooterContainer>
-      <S.ContentsContainer>
-        {topContents?.map((data) => {
-          return <S.Contents key={data.id}>{data.content}</S.Contents>;
-        })}
-      </S.ContentsContainer>
-
-      {bottomContents?.map((data) => {
+      {topContents?.map((data) => {
         return (
           <S.ContentsContainer key={data.id}>
             <S.Contents>{data.content}</S.Contents>
           </S.ContentsContainer>
         );
       })}
+
+      <S.ContentsContainer>
+        {middleContents?.map((data) => {
+          return (
+            <S.Contents key={data.id} $addMarginTop={data.id}>
+              {data.content}
+            </S.Contents>
+          );
+        })}
+      </S.ContentsContainer>
+
+      {middle2Contents?.map((data) => {
+        return (
+          <S.ContentsContainer key={data.id}>
+            <S.Contents>{data.content}</S.Contents>
+          </S.ContentsContainer>
+        );
+      })}
+
+      <S.ContentsContainer>
+        {bottomContents?.map((data) => {
+          return (
+            <S.Contents key={data.id} $addMarginTop={data.id}>
+              {data.content}
+            </S.Contents>
+          );
+        })}
+      </S.ContentsContainer>
     </S.CommonFooterContainer>
   );
 };

--- a/src/common/Footer/CommonFooter/index.tsx
+++ b/src/common/Footer/CommonFooter/index.tsx
@@ -1,0 +1,28 @@
+import useGetFooterContetnts from '../../../libs/hooks/useGetFooterContents';
+import * as S from './CommonFooter.style';
+
+const CommonFooter = () => {
+  const { res } = useGetFooterContetnts();
+  const topContents = res?.slice(0, 4);
+  const bottomContents = res?.slice(4, res.length);
+
+  return (
+    <S.CommonFooterContainer>
+      <S.ContentsContainer>
+        {topContents?.map((data) => {
+          return <S.Contents key={data.id}>{data.content}</S.Contents>;
+        })}
+      </S.ContentsContainer>
+
+      {bottomContents?.map((data) => {
+        return (
+          <S.ContentsContainer key={data.id}>
+            <S.Contents>{data.content}</S.Contents>
+          </S.ContentsContainer>
+        );
+      })}
+    </S.CommonFooterContainer>
+  );
+};
+
+export default CommonFooter;

--- a/src/common/Footer/Footer.style.ts
+++ b/src/common/Footer/Footer.style.ts
@@ -61,7 +61,7 @@ export const Link = styled.p`
   }
 `;
 
-export const Bar = styled.p`
+export const Bar = styled.div`
   display: flex;
   position: relative;
 

--- a/src/libs/hooks/useGetFooterContents.ts
+++ b/src/libs/hooks/useGetFooterContents.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import API from '../api';
+
+interface DataProps {
+  id: number;
+  content: string;
+}
+
+const useGetFooterContetnts = () => {
+  const [res, setRes] = useState<Array<DataProps> | undefined>();
+
+  const getContents = async () => {
+    try {
+      const res = await API.get(`/main/information`);
+      setRes(res.data.data);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  useEffect(() => {
+    getContents();
+  }, []);
+
+  return { res };
+};
+
+export default useGetFooterContetnts;

--- a/src/pages/ShowIpad/ShowIpad.style.ts
+++ b/src/pages/ShowIpad/ShowIpad.style.ts
@@ -19,3 +19,10 @@ export const NbContainer = styled.div`
 
   z-index: 15;
 `;
+
+export const FooterContainer = styled.footer`
+  width: 100%;
+  padding: 4.6rem 0 4rem;
+
+  background-color: ${({ theme: { colors } }) => colors.grayScale.gray2};
+`;

--- a/src/pages/ShowIpad/index.tsx
+++ b/src/pages/ShowIpad/index.tsx
@@ -12,6 +12,9 @@ import { GNB_CONTENTS } from '../../constant/gnbContents';
 import Banner from '../../common/Banner';
 import Nb from '../../common/Nb';
 import { useEffect, useState } from 'react';
+import Footer from '../../common/Footer';
+import { footerData } from '../../constant/footerData';
+import CommonFooter from '../../common/Footer/CommonFooter';
 
 interface RenderedCommonSectionProps {
   section: number;
@@ -95,6 +98,11 @@ const ShowIpadPage = () => {
           {renderCommonSection({ section: 8, productAsset: 7, subtitleIdx: 4 })}
         </S.ContentsContainer>
       </div>
+
+      <S.FooterContainer>
+        <CommonFooter />
+        <Footer data={footerData} />
+      </S.FooterContainer>
     </S.ShowIpadPageContainer>
   );
 };


### PR DESCRIPTION
## 🔥 Related Issues
resolved #85 

## 💜 작업 내용
- [x] 공통으로 사용할 footer를 구현했습니다.
- [x]  footer 내부에 들어갈 내용은 서버 통신으로 받아왔습니다.

## ✅ PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
  - 서버 통신 코드는 커스텀 훅으로 분리해주었습니다.
  ```typescript
    const useGetFooterContetnts = () => {
    const [res, setRes] = useState<Array<DataProps> | undefined>();

    const getContents = async () => {
      try {
        const res = await API.get(`/main/information`);
        setRes(res.data.data);
      } catch (err) {
        console.log(err);
      }
    };

     useEffect(() => {
      getContents();
     }, []);

     return { res };
   };
  ```
  
  - 서버에서 문장/ 단락 별로 데이터가 왔는데요, 피그마 상의 단락과 다른 부분이 있어서 데이터를 `topContents`와 `middleContents`, `middle2Contents`, `BottomContents`로 나눠서 사용해주었습니다.
  ```typescript
  const topContents = res?.slice(0, 4);
  const middleContents = res?.slice(3, 7);
  const middle2Contents = res?.slice(7, 9);
  const bottomContents = res?.slice(9, res.length - 1);
  ```
    

## 😡 Trouble Shooting
- 서버 데이터와 제가 가공하고자 하는 모양이랑 좀 달라서 고민했는데 데이터를 먼저 가공한 뒤, 스타일링하는 방식으로 해결했습니다.

## ☀️ 스크린샷 / GIF / 화면 녹화 
![스크린샷 2023-12-01 오후 7 57 44](https://github.com/DO-SOPT-CDS-SEMINAR/Apple-Client/assets/80264647/8bf43dea-17de-431d-a125-8bf3c015621e)

